### PR TITLE
making cromshell compatible with newer curl

### DIFF
--- a/cromwell
+++ b/cromwell
@@ -40,7 +40,7 @@ instruct()  # {{{
 }  # }}}
 
 function submit() { 
-  response=$(curl -s -F workflowSource=@${1} -F workflowInputs=@${2} -F workflowOptions=@${3} -F workflowDependencies=@${4} ${CROMWELL_URL}/api/workflows/v1)
+  response=$(curl -s -F workflowSource=@${1}  ${2:+ -F workflowInputs=@${2}} ${3:+ -F workflowOptions=@${3}} ${4:+ -F workflowDependencies=@${4}} ${CROMWELL_URL}/api/workflows/v1)
   echo $response  
   id=$(echo $response | cut -d"," -f1 | cut -d":" -f2 | sed s/\"//g | sed s/\ //g)
   mkdir $id


### PR DESCRIPTION
using a version of curl newer than curl ~7.43.0 would cause cromshell submit to fail silently
this was due to curl failing when a -F argument was given an empty filename
fixes #5