### PR TITLE
Allow override of CROMWELL_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ requires curl and [jq](https://stedolan.github.io/jq/)
  It will copy your wdl and json inputs into the folder for reproducibility.  
  * It keeps track of your most recently submitted jobs by storing their ids in `./cromshell/  
  You may ommit the job ID of the last job submitted when running commands, or use negative numbers to reference previous jobs.
+ * You can override the default cromwell server by setting the environmental variable CROMWELL_URL to the appropriate URL.

--- a/cromwell
+++ b/cromwell
@@ -3,8 +3,8 @@
 This=`basename $0`
 BinDir=`dirname $0`
 
-# FIXME: read env var, or default with this
-export CROMWELL_URL="https://cromwell-v30.dsde-methods.broadinstitute.org"
+# read env var, or use default server URL
+export CROMWELL_URL=${CROMWELL_URL:-"https://cromwell-v30.dsde-methods.broadinstitute.org"}
 
 
 CROMSHELL_CONFIG=$HOME/.cromshell


### PR DESCRIPTION
Altered behavior to retain default CROMWELL_URL but allow overriding
it by setting CROMWELL_URL as env var.

This resolves the FIXME comment previously at this location.