### PR TITLE
fix ping url

### DIFF
--- a/cromshell
+++ b/cromshell
@@ -194,7 +194,7 @@ function checkPrerequisites
 function assertCanCommunicateWithServer
 {
   # Make sure we can talk to the cromwell server:
-  serverName=$( echo ${1}| sed 's#.*://##g'| sed 's#:.*##g' )
+  serverName=$( echo ${1}| sed 's#.*://##g'| sed 's#:[0-9]*##g' )
   $PING_CMD $serverName &> /dev/null
   r=$?
   [[ $r -ne 0 ]] && error "Error: Cannot communicate with Cromwell server: $serverName" && exit 4

--- a/cromshell
+++ b/cromshell
@@ -194,7 +194,7 @@ function checkPrerequisites
 function assertCanCommunicateWithServer
 {
   # Make sure we can talk to the cromwell server:
-  serverName=$( echo ${1}| sed 's#.*://##g' )
+  serverName=$( echo ${1}| sed 's#.*://##g'| sed 's#:.*##g' )
   $PING_CMD $serverName &> /dev/null
   r=$?
   [[ $r -ne 0 ]] && error "Error: Cannot communicate with Cromwell server: $serverName" && exit 4


### PR DESCRIPTION
When my CROMWELL_URL is "http://localhost:8000",  the ":8000" string should be trimed.