### PR TITLE
Fix submitting with dependencies

### DIFF
--- a/cromshell
+++ b/cromshell
@@ -667,7 +667,7 @@ function submit()
 
   assertCanCommunicateWithServer $CROMWELL_URL
 
-  local response=$(curl --connect-timeout $CURL_CONNECT_TIMEOUT --max-time $CURL_MAX_TIMEOUT -s -F workflowSource=@${wdl}  ${2:+ -F workflowInputs=@${json}} ${3:+ -F workflowOptions=@${optionsJson}} ${4:+ -F workflowDependencies=@${depdenciesZip}} ${CROMWELL_URL}/api/workflows/v1)
+  local response=$(curl --connect-timeout $CURL_CONNECT_TIMEOUT --max-time $CURL_MAX_TIMEOUT -s -F workflowSource=@${wdl}  ${2:+ -F workflowInputs=@${json}} ${3:+ -F workflowOptions=@${optionsJson}} ${4:+ -F workflowDependencies=@${dependenciesZip}} ${CROMWELL_URL}/api/workflows/v1)
   local r=$?
 
   # Check to make sure that we actually submitted the job correctly 


### PR DESCRIPTION
Submitting with dependencies is broken due to a typo. This should fix it.