### PR TITLE
Update jq query to understand subworkflows

### DIFF
--- a/cromshell
+++ b/cromshell
@@ -313,6 +313,17 @@ function checkPrerequisites
   return 0
 }
 
+function checkJQVersion() {
+ local currentVersion="$( jq --version )"
+ local requiredVersion="jq-1.5"
+ if [ "$(printf '%s\n' "$requiredVersion" "$currentVersion" | sort -V | head -n1)" = "$requiredVersion" ]; then
+       return 0
+ else
+       error "ERROR: jq version must be at least ${requiredVersion}, you have ${currentVersion}."
+       return 1
+ fi
+}
+
 function assertRequiredFileIsNonEmpty()
 {
   local fileName=${1}
@@ -1804,6 +1815,10 @@ if ${ISINTERACTIVESHELL} ; then
   # Now that we have checked for help arguments, we can
   # make sure we have all the required commands:
   checkPrerequisites ${PREREQUISITES}
+  r=$?
+  [[ ${r} -ne 0 ]] && exit 6
+
+  checkJQVersion
   r=$?
   [[ ${r} -ne 0 ]] && exit 6
 

--- a/cromshell
+++ b/cromshell
@@ -834,12 +834,8 @@ function status()
 
     # Get execution status count and filter the metadata down:
     curl --compressed -s "${2}/api/workflows/v1/${1}/metadata?${CROMWELL_SLIM_METADATA_PARAMETERS}" > ${tmpMetadata}
-    
-    # Commented out due to limitations of jq 1.3 on some machines.  
-    # The following two lines are functionally equivalent:
-    #jq '.calls | map_values(group_by(.executionStatus) | map({(.[0].executionStatus): . | length}) | add)' ${tmpMetadata} > ${tmpExecutionStatusCount}
-    #jq '(.calls | to_entries[] | .key as $task_name | .value | group_by(.executionStatus) | map({(.[0].executionStatus): . | length}) | add | to_entries[] | { ($task_name): {(.key): .value} })' ${tmpMetadata} | jq -s '. | add' > ${tmpExecutionStatusCount}
-    jq -s 'map(.calls | to_entries[] |  {(.key): .value | map(.executionStatus) | group_by(.) | map({(.[0]): length}) | add} ) | add' ${tmpMetadata} > ${tmpExecutionStatusCount} 
+
+    jq '.. | .calls? | values | map_values(group_by(.executionStatus) | map({(.[0].executionStatus): . | length}) | add)' ${tmpMetadata} > ${tmpExecutionStatusCount} 
 
     # Check for failure states:
     cat ${tmpExecutionStatusCount} | grep -q 'Failed'
@@ -973,7 +969,7 @@ function execution-status-count()
     else
       # Make it json for a computer:
       # {tasks:{status: count}}
-      jq '.calls | map_values(group_by(.executionStatus) | map({(.[0].executionStatus): . | length}) | add)' "${tempFile}"
+      jq '.. | .calls? | values | map_values(group_by(.executionStatus) | map({(.[0].executionStatus): . | length}) | add)' "${tempFile}"
       checkPipeStatus "Could not read tmp file JSON data." "Could not parse JSON output from cromwell server."
     fi
   done

--- a/cromshell
+++ b/cromshell
@@ -314,6 +314,7 @@ function checkPrerequisites
 }
 
 function checkJQVersion() {
+ #With thanks to https://unix.stackexchange.com/a/285928/167681
  local currentVersion="$( jq --version )"
  local requiredVersion="jq-1.5"
  if [ "$(printf '%s\n' "$requiredVersion" "$currentVersion" | sort -V | head -n1)" = "$requiredVersion" ]; then


### PR DESCRIPTION
* This fixes a case where we would fail to mark doomed workflows as doomed.
* Partial fix https://github.com/broadinstitute/cromshell/issues/105
* We now require jq 1.5