### PR TITLE
Add counts as shorter alias of execution-status-count

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ requires `column`, `curl`, `mail`, and [jq](https://stedolan.github.io/jq/)
      * Get the full metadata of a workflow.
    * `slim-metadata` *`[workflow-id] [[workflow-id]...]`*           
      * Get a subset of the metadata from a workflow.
-   * `execution-status-count` *`[-p] [-x] [workflow-id] [[workflow-id]...]`*   
+   * `execution-status-count`, `counts` *`[-p] [-x] [workflow-id] [[workflow-id]...]`*   
      * Get the summarized status of all jobs in the workflow.
      * `-p` prints a pretty summary of the execution status instead of JSON
      * `-x` expands sub-workflows for more detailed summarization

--- a/completions/_cromshell
+++ b/completions/_cromshell
@@ -42,7 +42,7 @@ function _cromshell {
         cleanup)
           _cleanup
         ;;
-        execution-status-count)
+        execution-status-count|counts)
           _execution_status_count
         ;;
         notify)

--- a/cromshell
+++ b/cromshell
@@ -176,7 +176,7 @@ function usage()
   echo -e "   status [workflow-id] [[workflow-id]...]                           Check the status of a workflow."
   echo -e "   metadata [workflow-id] [[workflow-id]...]                         Get the full metadata of a workflow."
   echo -e "   slim-metadata [workflow-id] [[workflow-id]...]                    Get a subset of the metadata from a workflow."
-  echo -e "   execution-status-count [-p] [-x] [workflow-id] [[workflow-id]...] Get the summarized status of all jobs in the workflow."
+  echo -e "   execution-status-count, counts [-p] [-x] [workflow-id] [[workflow-id]...] Get the summarized status of all jobs in the workflow."
   echo -e "         -p               Enable pretty-printing."
   echo -e "         -x               Expand sub-workflow information."
   echo -e "   timing [workflow-id] [[workflow-id]...]                           Open the timing diagram in a browser."
@@ -992,6 +992,12 @@ function execution-status-count()
       checkPipeStatus "Could not read tmp file JSON data." "Could not parse JSON output from cromwell server."
     fi
   done
+}
+
+#a shorter alias of execution-status-count
+function counts()
+{
+  execution-status-count ${@}
 }
 
 # Almost the same as execution-status-count, but prettier!
@@ -1825,7 +1831,7 @@ if ${ISINTERACTIVESHELL} ; then
 
   # Validate our sub-command:
   case ${SUB_COMMAND} in
-    cleanup|submit|status|logs|execution-status-count|metadata|slim-metadata|timing|abort|notify|list|fetch-all|fetch-logs|list-outputs|alias)
+    cleanup|submit|status|logs|execution-status-count|counts|metadata|slim-metadata|timing|abort|notify|list|fetch-all|fetch-logs|list-outputs|alias)
       # This is a good sub-command, so we do not need to do anything. 
       ;;
     _rawNotify)
@@ -1867,7 +1873,7 @@ if ${ISINTERACTIVESHELL} ; then
   error "Sub-Command: ${SUB_COMMAND_FOR_DISPLAY}"
   case ${SUB_COMMAND} in 
     # These are the sub-commands that take arguments other than workflow IDs:
-    cleanup|submit|list|notify|execution-status-count|alias_workflow)
+    cleanup|submit|list|notify|execution-status-count|counts|alias_workflow)
       ${SUB_COMMAND} $@
       rv=$?
       ;;


### PR DESCRIPTION
* You can now use the alias counts instead of execution-status-count which is much shorter.