### PR TITLE
Excluded the notify daemon from the jq version check.

### DIFF
--- a/cromshell
+++ b/cromshell
@@ -1873,10 +1873,6 @@ if ${ISINTERACTIVESHELL} ; then
   r=$?
   [[ ${r} -ne 0 ]] && exit 6
 
-  checkJQVersion
-  r=$?
-  [[ ${r} -ne 0 ]] && exit 6
-
   # Sanitize the displayed sub-command:
   SUB_COMMAND_FOR_DISPLAY=${SUB_COMMAND}
   case ${SUB_COMMAND} in
@@ -1887,6 +1883,15 @@ if ${ISINTERACTIVESHELL} ; then
       SUB_COMMAND="alias_workflow"
       ;;
   esac
+
+  # Don't check JQ version if we're notifying.
+	# Why do this, you might ask?
+	# Because it's easier to hack our code than to get Broad IT to update software on our servers.
+  if [[ "${SUB_COMMAND_FOR_DISPLAY}" != "notify" ]] ; then
+    checkJQVersion
+    r=$?
+    [[ ${r} -ne 0 ]] && exit 6
+  fi
 
   # Handle specific sub-command args and and call our sub-command:
   error "Sub-Command: ${SUB_COMMAND_FOR_DISPLAY}"


### PR DESCRIPTION
This effectively bandages the issue of not being able to use the
notification daemons on Broad filesystems because IT won't upgrade our
version of JQ.

Any other systems that don't have a modern version of JQ are now capable of running the `notify` daemon as well. 