### PR TITLE
Fixing issue with aliases and GNU grep.

### DIFF
--- a/cromshell
+++ b/cromshell
@@ -522,8 +522,9 @@ function alias_workflow()
 function populateWorkflowIdAndServerFromAlias()
 {
     local alias_name=${1}
-    WORKFLOW_ID=$(grep "\\t${alias_name}\$" ${CROMWELL_SUBMISSIONS_FILE} | head -n1 | awk '{print $3}')
-    WORKFLOW_SERVER_URL=$(grep "\\t${alias_name}\$" ${CROMWELL_SUBMISSIONS_FILE} | head -n1 | awk '{print $2}')
+		WORKFLOW_ID=$(awk "BEGIN{FS=\"\t\"}{if (\$6 == \"${alias_name}\") {print}}" ${CROMWELL_SUBMISSIONS_FILE} | head -n1 | awk '{print $3}')
+		WORKFLOW_SERVER_URL=$(awk "BEGIN{FS=\"\t\"}{if (\$6 == \"${alias_name}\") {print}}" ${CROMWELL_SUBMISSIONS_FILE} | head -n1 | awk '{print $2}')
+
     if [[ -z ${WORKFLOW_ID} ]]; then
       error "Invalid workflow/alias: ${alias_name}"
       exit 5


### PR DESCRIPTION
- GNU grep doesn't like to work with tabs, so it wasn't properly parsing
the aliases out.  Removed the offending grep command so aliases can be
pulled from the TSV file on linux.
- Fixes #135