### PR TITLE
Add the sub-command "update-server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ requires `column`, `curl`, `mail`, and [jq](https://stedolan.github.io/jq/)
        where a completed state is one of: `Succeeded`, `Failed`, `Aborted`
      * *`-s STATUS`*     If provided, will only remove jobs with the given `STATUS` from the local list.
   
+   #### Update cromwell server
+   * `update-server`
+     * Change the cromwell server that new jobs will be submitted to.
     
  ### Features:
  * Running `submit` will create a new folder in the `~/.cromshell/${CROMWELL_URL}/` directory named with the cromwell job id of the newly submitted job.  

--- a/cromshell
+++ b/cromshell
@@ -204,6 +204,8 @@ function usage()
   echo -e "                          Will remove all jobs from the local list that are in a completed state,"
   echo -e "                          where a completed state is one of: $(echo ${TERMINAL_STATES} | tr ' ' ',' )" 
   echo -e "         -s STATUS        If provided, will only remove jobs with the given STATUS from the local list."
+  echo -e "  Update cromwell server:"
+  echo -e "   update-server          Change which cromwell server jobs will be submitted to."
   echo -e ""
   echo -e "Return values:"
   echo -e "  0                  SUCCESS"
@@ -1835,6 +1837,11 @@ if ${ISINTERACTIVESHELL} ; then
   # Get our sub-command:
   SUB_COMMAND=${1}
   shift
+
+  # Use the update-server sub-command to modify CROMWELL_NEEDS_SETUP here.
+  if [[ "${SUB_COMMAND}" == "update-server" ]] ; then
+    CROMWELL_NEEDS_SETUP=true
+  fi
   
   # Check if we need to set this up.
   # Note: because of how `notify` works, we can't require the setup for the notify action.


### PR DESCRIPTION
Absolutely feel free to shoot this down...

I was wanting to update my cromwell server in cromshell, and I always forget where the config file is located.  I thought it might be nice to have a sub-command which takes care of this.

I tried to make the smallest possible change in the code, so it might not be the most elegant solution... I've just reached in and set `CROMWELL_NEEDS_SETUP=true` if the new `update-server` sub-command is run, which should trigger the setup code that already exists.  Does that seem like an acceptable strategy?