### PR TITLE
Updated api_string variable

### DIFF
--- a/src/cromshell/status/command.py
+++ b/src/cromshell/status/command.py
@@ -23,9 +23,7 @@ def main(config, workflow_id):
     LOGGER.info("status")
 
     ret_val = 0
-    config.cromwell_api_workflow_id = (
-        f"{config.cromwell_server}{config.api_string}/{workflow_id}"
-    )
+    config.cromwell_api_workflow_id = f"{config.cromwell_api}/{workflow_id}"
 
     # Set cromwell server using submission file. Running the function below with
     # passing only the workflow id overrides the default cromwell url set in the

--- a/src/cromshell/status/command.py
+++ b/src/cromshell/status/command.py
@@ -24,7 +24,7 @@ def main(config, workflow_id):
 
     ret_val = 0
     config.cromwell_api_workflow_id = (
-        f"{config.cromwell_server}{config.api_string}{workflow_id}"
+        f"{config.cromwell_server}{config.api_string}/{workflow_id}"
     )
 
     # Set cromwell server using submission file. Running the function below with

--- a/src/cromshell/utilities/cromshellconfig.py
+++ b/src/cromshell/utilities/cromshellconfig.py
@@ -16,7 +16,7 @@ slim_metadata_parameters = (
     "=status&includeKey=callRoot&expandSubWorkflows=true&includeKey"
     "=subWorkflowMetadata&includeKey=subWorkflowId"
 )
-api_string = "/api/workflows/v1/"
+api_string = "/api/workflows/v1"
 # Concatenate the cromwell url, api string, and workflow ID. Set in subcommand.
 cromwell_api_workflow_id = None
 # Defaults for variables will be set after functions have been defined

--- a/src/cromshell/utilities/cromshellconfig.py
+++ b/src/cromshell/utilities/cromshellconfig.py
@@ -19,6 +19,7 @@ slim_metadata_parameters = (
 api_string = "/api/workflows/v1"
 # Concatenate the cromwell url, api string, and workflow ID. Set in subcommand.
 cromwell_api_workflow_id = None
+cromwell_api = None
 # Defaults for variables will be set after functions have been defined
 config_dir = None
 submission_file = None
@@ -151,3 +152,4 @@ config_dir = __get_config_dir()
 submission_file = __get_submission_file(config_dir)
 cromshell_config_options = __load_cromshell_config_file(config_dir)
 cromwell_server = __get_cromwell_server()
+cromwell_api = cromwell_server + api_string

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -13,9 +13,7 @@ def assert_can_communicate_with_server(config):
     """Check Connection with Cromwell Server"""
 
     try:
-        request_out = requests.get(
-            f"{config.cromwell_server}{config.api_string}/backends", timeout=5
-        )
+        request_out = requests.get(f"{config.cromwell_api}/backends", timeout=5)
     except ConnectionError:
         LOGGER.error("Failed to connect to %s", config.cromwell_server)
         raise Exception("Failed to connect to %s", config.cromwell_server)

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -14,7 +14,7 @@ def assert_can_communicate_with_server(config):
 
     try:
         request_out = requests.get(
-            f"{config.cromwell_server}{config.api_string}backends", timeout=5
+            f"{config.cromwell_server}{config.api_string}/backends", timeout=5
         )
     except ConnectionError:
         LOGGER.error("Failed to connect to %s", config.cromwell_server)


### PR DESCRIPTION
Updated api string variable in the cromshell config, http utility, and status file. The update involves removing the ending "/" at initial declaration of the variable and asks functions that use the variable to add the forward slash along with their needed extension. This enables cromshell api commands like the submit function which does not use additional extensions to use the variable without having to remove the forward slash. 