### PR TITLE
removed dataclasses in setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     license="BSD 3-Clause",
     long_description=open("README.md").read(),
     install_requires="""
-    dataclasses
     termcolor
     click>=8.0.0
     requests


### PR DESCRIPTION
Removed dataclasses from the setup.py because starting with python3.7, the package is included with python releases. ([reference](https://pypi.org/project/dataclasses/)). Cromshell only supports >=3.7