### PR TITLE
Shifted womtool installation to be the second step in git unit test workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,6 +20,11 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Install Womtool
+        run: |
+          $CONDA/bin/conda install -y -c bioconda womtool
+          echo "$CONDA/bin" >> $GITHUB_PATH
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -29,11 +34,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r dev-requirements.txt
-
-      - name: Install Womtool
-        run: |
-          $CONDA/bin/conda install -y -c bioconda womtool
-          echo "$CONDA/bin" >> $GITHUB_PATH
 
       - name: Install Tox
         run: pip install tox


### PR DESCRIPTION
Unit test is currently only using python 3.9 when running unit tests. This is due to the womtool step altering the python environment version. This pr shifts the womtool setup step before the python setup step so that the correct python version is being used before running the unit test scripts.