### PR TITLE
Fixing issue where tasks would be incorrectly labeled as failed.

### DIFF
--- a/cromshell
+++ b/cromshell
@@ -902,7 +902,7 @@ function status()
     jq '.. | .calls? | values | map_values(group_by(.executionStatus) | map({(.[0].executionStatus): . | length}) | add)' ${tmpMetadata} > ${tmpExecutionStatusCount} 
 
     # Check for failure states:
-    cat ${tmpExecutionStatusCount} | grep -q 'Failed'
+    cat ${tmpExecutionStatusCount} | grep -q '"Failed"'
     r=$?
 
     # Check for failures:


### PR DESCRIPTION
- Fixed problem in task parsing where if a task had the word `Failed` in
  it, it would be labeled as a failing task regardless of status.