### PR TITLE
Add error detail to when server communication fails

### DIFF
--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -27,7 +27,9 @@ def assert_can_communicate_with_server(config):
     if b"supportedBackends" not in request_out.content:
         log.display_logo(io_utils.dead_turtle)
         LOGGER.error(
-            "Error: Cannot communicate with Cromwell server: %s due to error %s", config.cromwell_server, request_out.content
+            "Error: Cannot communicate with Cromwell server: %s due to error %s",
+            config.cromwell_server,
+            request_out.content
         )
         raise Exception(
             f"Error: Cannot communicate with Cromwell server: {config.cromwell_server} due to error {request_out.content}"

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -27,7 +27,7 @@ def assert_can_communicate_with_server(config):
     if b"supportedBackends" not in request_out.content:
         log.display_logo(io_utils.dead_turtle)
         LOGGER.error(
-            "Error: Cannot communicate with Cromwell server: %s due to error %s",
+            "Error: Cannot communicate with Cromwell server: %s due to error: \n%s",
             config.cromwell_server,
             request_out.content,
         )

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -27,10 +27,10 @@ def assert_can_communicate_with_server(config):
     if b"supportedBackends" not in request_out.content:
         log.display_logo(io_utils.dead_turtle)
         LOGGER.error(
-            "Error: Cannot communicate with Cromwell server: %s", config.cromwell_server
+            "Error: Cannot communicate with Cromwell server: %s due to error %s", config.cromwell_server, request_out.content
         )
         raise Exception(
-            f"Error: Cannot communicate with Cromwell server: {config.cromwell_server}"
+            f"Error: Cannot communicate with Cromwell server: {config.cromwell_server} due to error {request_out.content}"
         )
 
 

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -29,7 +29,7 @@ def assert_can_communicate_with_server(config):
         LOGGER.error(
             "Error: Cannot communicate with Cromwell server: %s due to error %s",
             config.cromwell_server,
-            request_out.content
+            request_out.content,
         )
         raise Exception(
             f"Error: Cannot communicate with Cromwell server: {config.cromwell_server} due to error {request_out.content}"


### PR DESCRIPTION
For my feature I am communicating with a server that requires auth and I added this code to make my life easier.

Looks like this:
```
2022-04-29 11:54:35,728 cromshell.utilities.http_utils             ERROR    Error: Cannot communicate with Cromwell server: https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-dev-a2f0413e/terra-app-69e7caa2-993d-4a88-bc33-31f378bb9bd5/cromwell-service due to error: 
b'{"source":"leonardo","message":"Your account is not authenticated","statusCode":401,"exceptionClass":"class org.broadinstitute.dsde.workbench.leonardo.model.AuthenticationError","traceId":null}'
```