### PR TITLE
BW-1226 Add `referer_header_url` and `gcloud_token_email` options

### DIFF
--- a/src/cromshell/__main__.py
+++ b/src/cromshell/__main__.py
@@ -65,6 +65,16 @@ LOGGER = logging.getLogger(__name__)
     "The use of verification is strongly advised as per ssl documentation. "
     "Use this flag only when communicating with internal cromwell servers.",
 )
+@click.option(
+    "--gcloud_token_email",
+    type=str,
+    help="Call `gcloud auth print-access-token` with this email and add the token as an auth header to requests."
+)
+@click.option(
+    "--referer_header_url",
+    type=str,
+    help="For servers that require a referer, supply this URL in the `Referer:` header."
+)
 @click.pass_context
 def main_entry(
     cromshell_config,
@@ -73,6 +83,8 @@ def main_entry(
     cromwell_url,
     requests_timeout,
     requests_skip_certs,
+    gcloud_token_email,
+    referer_header_url,
 ):
     """
     Cromshell is a script for submitting workflows to a
@@ -97,6 +109,8 @@ def main_entry(
     cromshellconfig.resolve_cromwell_config_server_address(server_user=cromwell_url)
     cromshellconfig.override_requests_cert_parameters(skip_certs=requests_skip_certs)
     cromshellconfig.resolve_requests_connect_timeout(timeout_cli=requests_timeout)
+    cromshellconfig.resolve_gcloud_token_email(email=gcloud_token_email)
+    cromshellconfig.resolve_referer_header_url(url=referer_header_url)
 
 
 @main_entry.command()

--- a/src/cromshell/__main__.py
+++ b/src/cromshell/__main__.py
@@ -68,12 +68,12 @@ LOGGER = logging.getLogger(__name__)
 @click.option(
     "--gcloud_token_email",
     type=str,
-    help="Call `gcloud auth print-access-token` with this email and add the token as an auth header to requests."
+    help="Call `gcloud auth print-access-token` with this email and add the token as an auth header to requests.",
 )
 @click.option(
     "--referer_header_url",
     type=str,
-    help="For servers that require a referer, supply this URL in the `Referer:` header."
+    help="For servers that require a referer, supply this URL in the `Referer:` header.",
 )
 @click.pass_context
 def main_entry(

--- a/src/cromshell/abort/command.py
+++ b/src/cromshell/abort/command.py
@@ -30,7 +30,8 @@ def main(config, workflow_ids):
         http_utils.assert_can_communicate_with_server(config)
 
         requests_out = requests.post(
-            f"{config.cromwell_server}{config.API_STRING}/{wdl_id}/abort"
+            f"{config.cromwell_server}{config.API_STRING}/{wdl_id}/abort",
+            headers=http_utils.generate_headers(config),
         )
 
         if requests_out.ok:

--- a/src/cromshell/metadata/command.py
+++ b/src/cromshell/metadata/command.py
@@ -117,7 +117,7 @@ def obtain_and_print_metadata(
         api_workflow_id=config.cromwell_api_workflow_id,
         timeout=config.requests_connect_timeout,
         verify_certs=config.requests_verify_certs,
-        headers=http_utils.generate_headers(config)
+        headers=http_utils.generate_headers(config),
     )
 
     io_utils.pretty_print_json(workflow_metadata_json, add_color=True)

--- a/src/cromshell/metadata/command.py
+++ b/src/cromshell/metadata/command.py
@@ -79,6 +79,7 @@ def get_workflow_metadata(
     api_workflow_id: str,
     timeout: int,
     verify_certs: bool,
+    headers: map,
 ) -> str:
     """Uses requests to get the metadata or sub-metadata of a workflow
     from the cromwell server and returns a JSON formatted string."""
@@ -88,6 +89,7 @@ def get_workflow_metadata(
         params=meta_params,
         timeout=timeout,
         verify=verify_certs,
+        headers=headers,
     )
 
     http_utils.check_http_request_status_code(
@@ -115,6 +117,7 @@ def obtain_and_print_metadata(
         api_workflow_id=config.cromwell_api_workflow_id,
         timeout=config.requests_connect_timeout,
         verify_certs=config.requests_verify_certs,
+        headers=http_utils.generate_headers(config)
     )
 
     io_utils.pretty_print_json(workflow_metadata_json, add_color=True)

--- a/src/cromshell/status/command.py
+++ b/src/cromshell/status/command.py
@@ -37,6 +37,7 @@ def main(config, workflow_id):
         f"{config.cromwell_api_workflow_id}/status",
         timeout=config.requests_connect_timeout,
         verify=config.requests_verify_certs,
+        headers=http_utils.generate_headers(config),
     )
 
     requested_status_json = request_out.content.decode("utf-8")
@@ -68,6 +69,7 @@ def main(config, workflow_id):
             params=formatted_metadata_parameter,
             timeout=config.requests_connect_timeout,
             verify=config.requests_verify_certs,
+            headers=http_utils.generate_headers(config),
         )
 
         # metadata holds the workflow metadata as a dictionary

--- a/src/cromshell/submit/command.py
+++ b/src/cromshell/submit/command.py
@@ -196,6 +196,7 @@ def submit_workflow_to_server(wdl, wdl_json, options_json, dependencies_zip, con
             files=submission_params,
             timeout=config.requests_connect_timeout,
             verify=config.requests_verify_certs,
+            headers=http_utils.generate_headers(config),
         )
 
         return requests_out

--- a/src/cromshell/utilities/cromshellconfig.py
+++ b/src/cromshell/utilities/cromshellconfig.py
@@ -262,7 +262,7 @@ def resolve_referer_header_url(url: str):
         LOGGER.info("No referer header URL set.")
 
 
-def resolve_gcloud_token_email(email):
+def resolve_gcloud_token_email(email: str):
 
     global gcloud_token_email
 

--- a/src/cromshell/utilities/cromshellconfig.py
+++ b/src/cromshell/utilities/cromshellconfig.py
@@ -35,13 +35,14 @@ cromshell_config_options = None
 cromwell_server = None
 # Request defaults
 requests_connect_timeout = 5
+referer_header_url = None
+gcloud_token_email = None
 requests_verify_certs = True
 
 CROMSHELL_CONFIG_OPTIONS_TEMPLATE = {
     "cromwell_server": "String",
     "requests_timeout": requests_connect_timeout,
 }
-
 
 def override_requests_cert_parameters(skip_certs: bool):
     """Override requests settings for certs verification"""
@@ -243,6 +244,36 @@ def resolve_requests_connect_timeout(timeout_cli: int):
     else:
         LOGGER.info("Using requests default timeout duration.")
         LOGGER.info("Request Timeout value: %d sec", requests_connect_timeout)
+
+
+def resolve_referer_header_url(url: str):
+
+    global referer_header_url
+
+    if url:
+        LOGGER.info(f"Will send referer header {url} from command line options.")
+        referer_header_url = url
+    elif "referer_header_url" in cromshell_config_options:
+        config_url = cromshell_config_options["referer_header_url"]
+        LOGGER.info(f"Will send referer header {config_url} from config.")
+        referer_header_url = config_url
+    else:
+        LOGGER.info("No referer header URL set.")
+
+
+def resolve_gcloud_token_email(email):
+
+    global gcloud_token_email
+
+    if email:
+        LOGGER.info(f"Will send auth header with token for {email} from command line options.")
+        gcloud_token_email = email
+    elif "gcloud_token_email" in cromshell_config_options:
+        config_gcloud_token_email = cromshell_config_options["gcloud_token_email"]
+        LOGGER.info(f"Will send auth header with token for {config_gcloud_token_email} from config.")
+        gcloud_token_email = config_gcloud_token_email
+    else:
+        LOGGER.info("Not sending auth header.")
 
 
 # Get and Set Cromshell Configuration Default Values

--- a/src/cromshell/utilities/cromshellconfig.py
+++ b/src/cromshell/utilities/cromshellconfig.py
@@ -44,6 +44,7 @@ CROMSHELL_CONFIG_OPTIONS_TEMPLATE = {
     "requests_timeout": requests_connect_timeout,
 }
 
+
 def override_requests_cert_parameters(skip_certs: bool):
     """Override requests settings for certs verification"""
 
@@ -266,11 +267,15 @@ def resolve_gcloud_token_email(email):
     global gcloud_token_email
 
     if email:
-        LOGGER.info(f"Will send auth header with token for {email} from command line options.")
+        LOGGER.info(
+            f"Will send auth header with token for {email} from command line options."
+        )
         gcloud_token_email = email
     elif "gcloud_token_email" in cromshell_config_options:
         config_gcloud_token_email = cromshell_config_options["gcloud_token_email"]
-        LOGGER.info(f"Will send auth header with token for {config_gcloud_token_email} from config.")
+        LOGGER.info(
+            f"Will send auth header with token for {config_gcloud_token_email} from config."
+        )
         gcloud_token_email = config_gcloud_token_email
     else:
         LOGGER.info("Not sending auth header.")

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from subprocess import check_output
 
 import requests
 
@@ -76,10 +76,11 @@ def generate_headers(config):
         headers["Referer"] = config.referer_header_url
 
     if config.gcloud_token_email is not None:
-        stream = os.popen(
-            f"gcloud auth --account={config.gcloud_token_email} print-access-token"
+        out = check_output(  # Grab output, or raise error & halt Cromshell if nonzero exit code
+            ["gcloud", "auth", f"--account={config.gcloud_token_email}", "print-access-token"],
         )
-        token = stream.read().strip()  # Strip trailing newline
+
+        token = out.decode("utf-8").strip()  # Decode bytes, strip trailing newline
         headers["Authorization"] = f"Bearer {token}"
 
     return headers

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -76,7 +76,9 @@ def generate_headers(config):
         headers["Referer"] = config.referer_header_url
 
     if config.gcloud_token_email is not None:
-        stream = os.popen(f"gcloud auth --account={config.gcloud_token_email} print-access-token")
+        stream = os.popen(
+            f"gcloud auth --account={config.gcloud_token_email} print-access-token"
+        )
         token = stream.read().strip()  # Strip trailing newline
         headers["Authorization"] = f"Bearer {token}"
 

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import requests
 
@@ -16,6 +17,7 @@ def assert_can_communicate_with_server(config):
             f"{config.get_cromwell_api()}/backends",
             timeout=config.requests_connect_timeout,
             verify=config.requests_verify_certs,
+            headers=generate_headers(config),
         )
     except ConnectionError:
         LOGGER.error("Failed to connect to %s", config.cromwell_server)
@@ -61,3 +63,21 @@ def check_http_request_status_code(
                 f"Status_code: {response.status_code}\n"
                 f"Message: {response.text}"
             )
+
+
+def generate_headers(config):
+    """
+    Check the config for options that require a header and generate the appropriate map.
+    Will be an empty map if no relevant options are specified.
+    """
+    headers = {}
+
+    if config.referer_header_url is not None:
+        headers["Referer"] = config.referer_header_url
+
+    if config.gcloud_token_email is not None:
+        stream = os.popen(f"gcloud auth --account={config.gcloud_token_email} print-access-token")
+        token = stream.read().strip()  # Strip trailing newline
+        headers["Authorization"] = f"Bearer {token}"
+
+    return headers

--- a/src/cromshell/utilities/http_utils.py
+++ b/src/cromshell/utilities/http_utils.py
@@ -77,7 +77,12 @@ def generate_headers(config):
 
     if config.gcloud_token_email is not None:
         out = check_output(  # Grab output, or raise error & halt Cromshell if nonzero exit code
-            ["gcloud", "auth", f"--account={config.gcloud_token_email}", "print-access-token"],
+            [
+                "gcloud",
+                "auth",
+                f"--account={config.gcloud_token_email}",
+                "print-access-token",
+            ],
         )
 
         token = out.decode("utf-8").strip()  # Decode bytes, strip trailing newline

--- a/tests/unit/test_cromshellconfig.py
+++ b/tests/unit/test_cromshellconfig.py
@@ -220,9 +220,81 @@ class TestCromshellConfig:
             cromshellconfig.requests_connect_timeout == 10
         ), "Requests timeout duration should be set to 10 sec"
 
+    def test_resolve_referer_header_url_default(self):
+        reload(cromshellconfig)
+        assert (
+            cromshellconfig.referer_header_url is None
+        ), "Default `referer_header_url` should be None"
+
+    def test_resolve_referer_header_url_config(
+        self, test_config_referer_header_url
+    ):
+        reload(cromshellconfig)
+        referer_header_url_cli = None
+        cromshellconfig.resolve_referer_header_url(referer_header_url_cli)
+
+        assert (
+            cromshellconfig.referer_header_url == "https://from_config.example.com"
+        ), "Use config value in absence of CLI"
+
+    def test_resolve_referer_header_url_cli(
+        self, test_config_referer_header_url
+    ):
+        reload(cromshellconfig)
+        referer_header_url_cli = "https://from_cli.example.com"
+        cromshellconfig.resolve_referer_header_url(referer_header_url_cli)
+
+        assert (
+                cromshellconfig.referer_header_url == "https://from_cli.example.com"
+        ), "CLI overrides config"
+
+    def test_resolve_gcloud_token_email_default(self):
+        reload(cromshellconfig)
+        assert (
+            cromshellconfig.gcloud_token_email is None
+        ), "Default `gcloud_token_email` should be None"
+
+    def test_resolve_gcloud_token_email_config(
+        self, test_config_gcloud_token_email
+    ):
+        reload(cromshellconfig)
+        gcloud_token_email_cli = None
+        cromshellconfig.resolve_gcloud_token_email(gcloud_token_email_cli)
+
+        assert (
+            cromshellconfig.gcloud_token_email == "from_config@example.com"
+        ), "Use config value in absence of CLI"
+
+    def test_resolve_gcloud_token_email_cli(
+        self, test_config_gcloud_token_email
+    ):
+        reload(cromshellconfig)
+        gcloud_token_email_cli = "from_cli@example.com"
+        cromshellconfig.resolve_referer_header_url(gcloud_token_email_cli)
+
+        assert (
+                cromshellconfig.referer_header_url == "from_cli@example.com"
+        ), "CLI overrides config"
+
     @pytest.fixture
     def mock_data_path(self):
         return os.path.join(os.path.dirname(__file__), "mock_data/")
+
+    @pytest.fixture
+    def test_config_empty(self):
+        return {}
+
+    @pytest.fixture
+    def test_config_gcloud_token_email(self):
+        return {
+            "gcloud_token_email": "from_config@example.com"
+        }
+
+    @pytest.fixture
+    def test_config_referer_header_url(self):
+        return {
+            "referer_header_url": "https://from_config.example.com"
+        }
 
     @pytest.fixture
     def test_config_options_with_timeout(self):

--- a/tests/unit/test_cromshellconfig.py
+++ b/tests/unit/test_cromshellconfig.py
@@ -230,6 +230,7 @@ class TestCromshellConfig:
         self, test_config_referer_header_url
     ):
         reload(cromshellconfig)
+        cromshellconfig.cromshell_config_options = test_config_referer_header_url
         referer_header_url_cli = None
         cromshellconfig.resolve_referer_header_url(referer_header_url_cli)
 
@@ -241,6 +242,7 @@ class TestCromshellConfig:
         self, test_config_referer_header_url
     ):
         reload(cromshellconfig)
+        cromshellconfig.cromshell_config_options = test_config_referer_header_url
         referer_header_url_cli = "https://from_cli.example.com"
         cromshellconfig.resolve_referer_header_url(referer_header_url_cli)
 
@@ -258,6 +260,7 @@ class TestCromshellConfig:
         self, test_config_gcloud_token_email
     ):
         reload(cromshellconfig)
+        cromshellconfig.cromshell_config_options = test_config_gcloud_token_email
         gcloud_token_email_cli = None
         cromshellconfig.resolve_gcloud_token_email(gcloud_token_email_cli)
 
@@ -269,6 +272,7 @@ class TestCromshellConfig:
         self, test_config_gcloud_token_email
     ):
         reload(cromshellconfig)
+        cromshellconfig.cromshell_config_options = test_config_gcloud_token_email
         gcloud_token_email_cli = "from_cli@example.com"
         cromshellconfig.resolve_referer_header_url(gcloud_token_email_cli)
 

--- a/tests/unit/test_cromshellconfig.py
+++ b/tests/unit/test_cromshellconfig.py
@@ -226,9 +226,7 @@ class TestCromshellConfig:
             cromshellconfig.referer_header_url is None
         ), "Default `referer_header_url` should be None"
 
-    def test_resolve_referer_header_url_config(
-        self, test_config_referer_header_url
-    ):
+    def test_resolve_referer_header_url_config(self, test_config_referer_header_url):
         reload(cromshellconfig)
         cromshellconfig.cromshell_config_options = test_config_referer_header_url
         referer_header_url_cli = None
@@ -238,9 +236,7 @@ class TestCromshellConfig:
             cromshellconfig.referer_header_url == "https://from_config.example.com"
         ), "Use config value in absence of CLI"
 
-    def test_resolve_referer_header_url_cli(
-        self, test_config_referer_header_url
-    ):
+    def test_resolve_referer_header_url_cli(self, test_config_referer_header_url):
         reload(cromshellconfig)
         cromshellconfig.cromshell_config_options = test_config_referer_header_url
         referer_header_url_cli = "https://from_cli.example.com"
@@ -256,9 +252,7 @@ class TestCromshellConfig:
             cromshellconfig.gcloud_token_email is None
         ), "Default `gcloud_token_email` should be None"
 
-    def test_resolve_gcloud_token_email_config(
-        self, test_config_gcloud_token_email
-    ):
+    def test_resolve_gcloud_token_email_config(self, test_config_gcloud_token_email):
         reload(cromshellconfig)
         cromshellconfig.cromshell_config_options = test_config_gcloud_token_email
         gcloud_token_email_cli = None
@@ -268,16 +262,14 @@ class TestCromshellConfig:
             cromshellconfig.gcloud_token_email == "from_config@example.com"
         ), "Use config value in absence of CLI"
 
-    def test_resolve_gcloud_token_email_cli(
-        self, test_config_gcloud_token_email
-    ):
+    def test_resolve_gcloud_token_email_cli(self, test_config_gcloud_token_email):
         reload(cromshellconfig)
         cromshellconfig.cromshell_config_options = test_config_gcloud_token_email
         gcloud_token_email_cli = "from_cli@example.com"
         cromshellconfig.resolve_referer_header_url(gcloud_token_email_cli)
 
         assert (
-                cromshellconfig.referer_header_url == "from_cli@example.com"
+            cromshellconfig.referer_header_url == "from_cli@example.com"
         ), "CLI overrides config"
 
     @pytest.fixture
@@ -290,15 +282,11 @@ class TestCromshellConfig:
 
     @pytest.fixture
     def test_config_gcloud_token_email(self):
-        return {
-            "gcloud_token_email": "from_config@example.com"
-        }
+        return {"gcloud_token_email": "from_config@example.com"}
 
     @pytest.fixture
     def test_config_referer_header_url(self):
-        return {
-            "referer_header_url": "https://from_config.example.com"
-        }
+        return {"referer_header_url": "https://from_config.example.com"}
 
     @pytest.fixture
     def test_config_options_with_timeout(self):

--- a/tests/unit/test_cromshellconfig.py
+++ b/tests/unit/test_cromshellconfig.py
@@ -243,7 +243,7 @@ class TestCromshellConfig:
         cromshellconfig.resolve_referer_header_url(referer_header_url_cli)
 
         assert (
-                cromshellconfig.referer_header_url == "https://from_cli.example.com"
+            cromshellconfig.referer_header_url == "https://from_cli.example.com"
         ), "CLI overrides config"
 
     def test_resolve_gcloud_token_email_default(self):

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -22,6 +22,9 @@ class TestHTTPUtilities:
                 short_error_message="TEST", response=mock_failed_response
             ), "If response.ok is False then exception should be raised"
 
+    def test_generate_headers(self):
+        http_utils.generate_headers()
+
     @pytest.fixture
     def mock_pass_response(self):
         """Create requests response object to be hold mock response"""

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -22,9 +22,6 @@ class TestHTTPUtilities:
                 short_error_message="TEST", response=mock_failed_response
             ), "If response.ok is False then exception should be raised"
 
-    def test_generate_headers(self):
-        http_utils.generate_headers()
-
     @pytest.fixture
     def mock_pass_response(self):
         """Create requests response object to be hold mock response"""


### PR DESCRIPTION
This is in support of communicating with Cromwells that require authentication, such as:
1. Cromwells configured with a CromIAM instance in front
    - Requires auth header
2. "Cromwell as an app" running in a Terra workspace
    - Requires auth header and referer URL
    - Server URL looks like `https://leonardo.dsde-dev.broadinstitute.org/proxy/google/v1/apps/terra-dev-a2f0413e/terra-app-69e7caa2-993d-4a88-bc33-31f378bb9bd5/cromwell-service` because requests to Cromwell go via the Leonardo proxy
    - Referer looks like `https://leonardo.dsde-dev.broadinstitute.org`