### PR TITLE
Added cromwell auth parameters to cromshell config template

### DIFF
--- a/src/cromshell/utilities/config_options_file_utils.py
+++ b/src/cromshell/utilities/config_options_file_utils.py
@@ -5,7 +5,12 @@ from pathlib import Path
 LOGGER = logging.getLogger(__name__)
 
 
-CONFIG_FILE_TEMPLATE = {"cromwell_server": "str", "requests_timeout": "int"}
+CONFIG_FILE_TEMPLATE = {
+    "cromwell_server": "str",
+    "requests_timeout": "int",
+    "gcloud_token_email": "str",
+    "referer_header_url": "str",
+}
 
 
 def valid_json(json_to_validate: str or Path, json_is_file_path: bool = True) -> bool:


### PR DESCRIPTION
Cromshell checks both the command parameters and config file for the following Cromwell auth parameters `gcloud_token_email` and `referer_header_url`, so adding them to the config template