### PR TITLE
Add option to not color json output to main command

### DIFF
--- a/src/cromshell/__main__.py
+++ b/src/cromshell/__main__.py
@@ -88,6 +88,11 @@ LOGGER = logging.getLogger(__name__)
     type=str,
     help="For servers that require a referer, supply this URL in the `Referer:` header.",
 )
+@click.option(
+    "--no_json_color",
+    flag_value=True,
+    help="Disables colorized JSON output.",
+)
 @click.pass_context
 def main_entry(
     cromshell_config,
@@ -98,6 +103,7 @@ def main_entry(
     requests_skip_certs,
     gcloud_token_email,
     referer_header_url,
+    no_json_color,
 ):
     """
     Cromshell is a script for submitting workflows to a
@@ -127,6 +133,7 @@ def main_entry(
     cromshellconfig.resolve_requests_connect_timeout(timeout_cli=requests_timeout)
     cromshellconfig.resolve_gcloud_token_email(email=gcloud_token_email)
     cromshellconfig.resolve_referer_header_url(url=referer_header_url)
+    cromshellconfig.resolve_color_json(color=not no_json_color)
 
 
 @main_entry.command()

--- a/src/cromshell/__main__.py
+++ b/src/cromshell/__main__.py
@@ -89,9 +89,18 @@ LOGGER = logging.getLogger(__name__)
     help="For servers that require a referer, supply this URL in the `Referer:` header.",
 )
 @click.option(
-    "--no_json_color",
+    "-mc",
+    "--machine_processable",
+    "machine_processable",
     flag_value=True,
-    help="Disables colorized JSON output.",
+    help="Avoids the use of color and other human readable formatting for output.",
+)
+@click.option(
+    "-co",
+    "--colorful_output",
+    "colorful_output",
+    flag_value=True,
+    help="Uses color and other human readable formatting for output when possible.",
 )
 @click.pass_context
 def main_entry(
@@ -103,7 +112,8 @@ def main_entry(
     requests_skip_certs,
     gcloud_token_email,
     referer_header_url,
-    no_json_color,
+    machine_processable,
+    colorful_output,
 ):
     """
     Cromshell is a script for submitting workflows to a
@@ -133,7 +143,9 @@ def main_entry(
     cromshellconfig.resolve_requests_connect_timeout(timeout_cli=requests_timeout)
     cromshellconfig.resolve_gcloud_token_email(email=gcloud_token_email)
     cromshellconfig.resolve_referer_header_url(url=referer_header_url)
-    cromshellconfig.resolve_color_json(color=not no_json_color)
+    cromshellconfig.resolve_color_output(
+        machine_readable=machine_processable, colorful_output=colorful_output
+    )
 
 
 @main_entry.command()

--- a/src/cromshell/counts/command.py
+++ b/src/cromshell/counts/command.py
@@ -197,11 +197,12 @@ def print_call_status(call: str, indent: str, workflow_calls_metadata: dict) -> 
         )
 
 
-def print_task_status_summary(workflow_metadata: dict) -> None:
+def print_task_status_summary(workflow_metadata: dict, print_color: bool = None) -> None:
     """
     Prints the status count for each task in a workflow.
     Does NOT run expose subworkflows
 
+    :param print_color: If True, print status summary with color
     :param workflow_metadata: Metadata of the workflow to process
     :return:
     """
@@ -214,7 +215,7 @@ def print_task_status_summary(workflow_metadata: dict) -> None:
         # task status counts
         workflow_status_summary[task] = get_shard_status_count(shards=shards)
 
-    io_utils.pretty_print_json(format_json=workflow_status_summary)
+    io_utils.pretty_print_json(format_json=workflow_status_summary, add_color=print_color)
 
 
 def get_shard_status_count(shards: list) -> Dict[str, int]:

--- a/src/cromshell/counts/command.py
+++ b/src/cromshell/counts/command.py
@@ -197,7 +197,9 @@ def print_call_status(call: str, indent: str, workflow_calls_metadata: dict) -> 
         )
 
 
-def print_task_status_summary(workflow_metadata: dict, print_color: bool = None) -> None:
+def print_task_status_summary(
+    workflow_metadata: dict, print_color: bool = None
+) -> None:
     """
     Prints the status count for each task in a workflow.
     Does NOT run expose subworkflows
@@ -215,7 +217,9 @@ def print_task_status_summary(workflow_metadata: dict, print_color: bool = None)
         # task status counts
         workflow_status_summary[task] = get_shard_status_count(shards=shards)
 
-    io_utils.pretty_print_json(format_json=workflow_status_summary, add_color=print_color)
+    io_utils.pretty_print_json(
+        format_json=workflow_status_summary, add_color=print_color
+    )
 
 
 def get_shard_status_count(shards: list) -> Dict[str, int]:

--- a/src/cromshell/metadata/command.py
+++ b/src/cromshell/metadata/command.py
@@ -108,4 +108,4 @@ def obtain_and_print_metadata(
         headers=http_utils.generate_headers(config),
     )
 
-    io_utils.pretty_print_json(format_json=workflow_metadata_json, add_color=True)
+    io_utils.pretty_print_json(format_json=workflow_metadata_json)

--- a/src/cromshell/utilities/cromshellconfig.py
+++ b/src/cromshell/utilities/cromshellconfig.py
@@ -42,7 +42,7 @@ requests_connect_timeout = 5
 referer_header_url = None
 gcloud_token_email = None
 requests_verify_certs = True
-color_json = True
+color_output = None
 
 CROMSHELL_CONFIG_OPTIONS_TEMPLATE = {
     "cromwell_server": "String",
@@ -316,14 +316,25 @@ def resolve_gcloud_token_email(email: str):
         LOGGER.info("Not sending auth header.")
 
 
-def resolve_color_json(color: bool) -> None:
+def resolve_color_output(machine_readable: bool, colorful_output: bool) -> None:
     """Override the default color json output.
     Arg color: True or False"""
-    global color_json
+    global color_output
 
-    if color is False or not sys.stdout.isatty():
+    if machine_readable and colorful_output:
+        LOGGER.error("Cannot color json output and be machine readable.")
+        LOGGER.error("Please choose one or the other Cromshell flags.")
+        raise ValueError("Cannot color json output and be machine readable.")
+
+    if machine_readable:
         LOGGER.debug("Will not color json output.")
-        color_json = False
+        color_output = False
+    elif colorful_output or sys.stdout.isatty():
+        LOGGER.debug("Will color json output.")
+        color_output = True
+    else:
+        LOGGER.debug("Will not color json output.")
+        color_output = False
 
 
 # Get and Set Cromshell Configuration Default Values

--- a/src/cromshell/utilities/cromshellconfig.py
+++ b/src/cromshell/utilities/cromshellconfig.py
@@ -2,6 +2,7 @@ import csv
 import json
 import logging
 import os
+import sys
 import warnings
 from enum import Enum
 from pathlib import Path
@@ -41,6 +42,7 @@ requests_connect_timeout = 5
 referer_header_url = None
 gcloud_token_email = None
 requests_verify_certs = True
+color_json = True
 
 CROMSHELL_CONFIG_OPTIONS_TEMPLATE = {
     "cromwell_server": "String",
@@ -312,6 +314,16 @@ def resolve_gcloud_token_email(email: str):
         gcloud_token_email = config_gcloud_token_email
     else:
         LOGGER.info("Not sending auth header.")
+
+
+def resolve_color_json(color: bool) -> None:
+    """Override the default color json output.
+    Arg color: True or False"""
+    global color_json
+
+    if color is False or not sys.stdout.isatty():
+        LOGGER.debug("Will not color json output.")
+        color_json = False
 
 
 # Get and Set Cromshell Configuration Default Values

--- a/src/cromshell/utilities/io_utils.py
+++ b/src/cromshell/utilities/io_utils.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import shutil
+import sys
 from contextlib import nullcontext
 from io import BytesIO
 from pathlib import Path
@@ -9,6 +10,7 @@ from typing import BinaryIO, List, Union
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from pygments import formatters, highlight, lexers
+import rich
 from termcolor import colored
 
 LOGGER = logging.getLogger(__name__)
@@ -162,10 +164,15 @@ def color_json(formatted_json: str) -> str:
     return highlight(formatted_json, lexers.JsonLexer(), formatters.TerminalFormatter())
 
 
-def pretty_print_json(format_json: str or dict, add_color: bool = False) -> None:
+def pretty_print_json(format_json: str or dict, add_color: bool = None) -> None:
     """Prints JSON String in a fancy way
 
     - json_text: valid json string or dictionary, NOT json file path"""
+
+    # Importing here to retrieve color_json value after being resolved by main()
+    from cromshell.utilities.cromshellconfig import color_json as csc_color_json
+    if add_color is None:
+        add_color = csc_color_json
 
     if format_json is type(str):
         loaded_json = json.loads(format_json)

--- a/src/cromshell/utilities/io_utils.py
+++ b/src/cromshell/utilities/io_utils.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 import shutil
-import sys
 from contextlib import nullcontext
 from io import BytesIO
 from pathlib import Path
@@ -10,7 +9,6 @@ from typing import BinaryIO, List, Union
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from pygments import formatters, highlight, lexers
-import rich
 from termcolor import colored
 
 LOGGER = logging.getLogger(__name__)
@@ -167,10 +165,14 @@ def color_json(formatted_json: str) -> str:
 def pretty_print_json(format_json: str or dict, add_color: bool = None) -> None:
     """Prints JSON String in a fancy way
 
-    - json_text: valid json string or dictionary, NOT json file path"""
+    Args:
+    - json_text: valid json string or dictionary, NOT json file path
+    - add_color: whether to add color to the json string
+    """
 
     # Importing here to retrieve color_json value after being resolved by main()
     from cromshell.utilities.cromshellconfig import color_json as csc_color_json
+
     if add_color is None:
         add_color = csc_color_json
 

--- a/src/cromshell/utilities/io_utils.py
+++ b/src/cromshell/utilities/io_utils.py
@@ -171,7 +171,7 @@ def pretty_print_json(format_json: str or dict, add_color: bool = None) -> None:
     """
 
     # Importing here to retrieve color_json value after being resolved by main()
-    from cromshell.utilities.cromshellconfig import color_json as csc_color_json
+    from cromshell.utilities.cromshellconfig import color_output as csc_color_json
 
     if add_color is None:
         add_color = csc_color_json

--- a/tests/unit/test_counts.py
+++ b/tests/unit/test_counts.py
@@ -107,7 +107,9 @@ class TestCounts:
         with open(mock_data_path.joinpath(metadata_name), "r") as f:
             workflow_metadata = json.load(f)
 
-        counts_command.print_task_status_summary(workflow_metadata=workflow_metadata)
+        counts_command.print_task_status_summary(
+            workflow_metadata=workflow_metadata, print_color=False
+        )
         captured = capsys.readouterr()
         assert captured.out.rstrip() == json.dumps(
             task_summary, indent=4, sort_keys=True

--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -101,7 +101,7 @@ class TestIOUtilities:
                 """{"id":"4bf7ca9c-0b39-48fb-9af7-83e3e488f62b","status":"Submitted"}""",
                 True,
                 """\x1b[33m"{\\"id\\":\\"4bf7ca9c-0b39-48fb-9af7-83e3e488f62b\\",\\"status\\":\\"Submitted\\"}"\x1b[39;49;00m\x1b[37m\x1b[39;49;00m\n\n""",
-            )
+            ),
         ],
     )
     def test_pretty_print_json(self, testing_input, add_color, test_output):

--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -90,24 +90,28 @@ class TestIOUtilities:
     # TODO: test something with at least 1 level of nesting
     #  to show it works on a non-trivial example.
     @pytest.mark.parametrize(
-        "testing_input, test_output",
+        "testing_input, add_color, test_output",
         [
             (
-                (
-                    """{"id":"4bf7ca9c-0b39-48fb-9af7-83e3e488f62b","status":"Submitted"}"""
-                ),
-                (
-                    """\"{\\"id\\":\\"4bf7ca9c-0b39-48fb-9af7-83e3e488f62b\\",\\"status\\":\\"Submitted\\"}\"\n"""
-                ),
+                """{"id":"4bf7ca9c-0b39-48fb-9af7-83e3e488f62b","status":"Submitted"}""",
+                False,
+                """\"{\\"id\\":\\"4bf7ca9c-0b39-48fb-9af7-83e3e488f62b\\",\\"status\\":\\"Submitted\\"}\"\n""",
             ),
+            (
+                """{"id":"4bf7ca9c-0b39-48fb-9af7-83e3e488f62b","status":"Submitted"}""",
+                True,
+                """\x1b[33m"{\\"id\\":\\"4bf7ca9c-0b39-48fb-9af7-83e3e488f62b\\",\\"status\\":\\"Submitted\\"}"\x1b[39;49;00m\x1b[37m\x1b[39;49;00m\n\n""",
+            )
         ],
     )
-    def test_pretty_print_json(self, testing_input, test_output):
+    def test_pretty_print_json(self, testing_input, add_color, test_output):
         # Here the function is being run and allows us to redirect the stdout which
         # would be what the function prints to the screen to file like object
         func_stdout = io.StringIO()
         with redirect_stdout(func_stdout):
-            io_utils.pretty_print_json(testing_input)
+            io_utils.pretty_print_json(testing_input, add_color=add_color)
+
+        print(func_stdout.getvalue())
 
         # assert the function stdout is the same as the expected out
         assert func_stdout.getvalue() == test_output


### PR DESCRIPTION
- Centralized json coloring setting to cromshellconfig.py, 
- Added option to disable coloring in main command
- By default json coloring is true
- JSON coloring is disabled if the output is pipped to file