### PR TITLE
Version Command fix

### DIFF
--- a/src/cromshell/__main__.py
+++ b/src/cromshell/__main__.py
@@ -153,8 +153,14 @@ def main_entry(
 
 @main_entry.command()
 def version():
-    """Print the version of cromshell"""
+    """Command to print the version of cromshell"""
     LOGGER.info("cromshell %s", __version__)
+    print_version()
+
+
+def print_version():
+    """Print the version of cromshell"""
+    print(f"cromshell {__version__}")
 
 
 # Update with new sub-commands:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,3 +32,14 @@ def local_cromshell_config_json(local_hidden_cromshell_folder):
 @pytest.fixture
 def test_workflows_path():
     return Path(__file__).joinpath("workflows/")
+
+
+@pytest.fixture
+def get_current_version() -> str:
+    filename = Path(__file__).parents[1].joinpath("src/cromshell/__main__.py")
+    with open(filename) as f:
+        for line in f:
+            if line.startswith('__version__'):
+                version = line.split('=')[1].strip().strip('\'\"')
+
+    return version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def get_current_version() -> str:
     filename = Path(__file__).parents[1].joinpath("src/cromshell/__main__.py")
     with open(filename) as f:
         for line in f:
-            if line.startswith('__version__'):
-                version = line.split('=')[1].strip().strip('\'\"')
+            if line.startswith("__version__"):
+                version = line.split("=")[1].strip().strip("\'\"")
 
     return version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,6 @@ def get_current_version() -> str:
     with open(filename) as f:
         for line in f:
             if line.startswith("__version__"):
-                version = line.split("=")[1].strip().strip("\'\"")
+                version = line.split("=")[1].strip().strip('"')
 
     return version

--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -1,0 +1,16 @@
+from tests.integration import utility_test_functions
+
+
+class TestVersion:
+    """Test the version command."""
+
+    def test_version(self, get_current_version):
+        version_result = utility_test_functions.run_cromshell_command(
+            command=["version"],
+            exit_code=0,
+        )
+
+        print("Print version results:")
+        print(version_result.stdout)
+
+        assert version_result.stdout == "cromshell " + get_current_version + "\n"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,13 @@
+from src.cromshell.__main__ import print_version
+
+
+class TestVersion:
+    """Test the version command functions."""
+
+    def test_version(self, get_current_version, capsys):
+
+        cromshell_version = get_current_version
+
+        print_version()
+        captured = capsys.readouterr()
+        assert captured.out == "cromshell " + cromshell_version + "\n"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -5,7 +5,6 @@ class TestVersion:
     """Test the version command functions."""
 
     def test_version(self, get_current_version, capsys):
-
         cromshell_version = get_current_version
 
         print_version()


### PR DESCRIPTION
The version command currently only displays the version of cromshell through Logger.info, but the logger by default is set to show only warnings/errors. 

This fix is to have the version command `print` the version and add unit/integration test for the command.