### PR TITLE
Detect and flatten nested WDL directories

### DIFF
--- a/src/cromshell/submit/command.py
+++ b/src/cromshell/submit/command.py
@@ -4,6 +4,9 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path, PurePath
+import tempfile
+
+import os
 
 import click
 import requests
@@ -64,6 +67,11 @@ def main(config, wdl, wdl_json, options_json, dependencies_zip, no_validation):
     LOGGER.info("submit")
 
     http_utils.assert_can_communicate_with_server(config=config)
+
+    if io_utils.has_nested_dependencies(wdl):
+        tempdir = tempfile.TemporaryDirectory(prefix='cromshell_')
+        wdl = io_utils.flatten_nested_dependencies(tempdir, wdl)
+        dependencies_zip = tempdir.name
 
     if no_validation:
         LOGGER.info("Skipping WDL validation")


### PR DESCRIPTION
One common problem we encounter is path resolution for WDLs within a nested directory structure. While a nested file organization is better for readability and maintainability, Cromwell cannot always resolve the file locations properly. Within Terra, dependencies are resolved via Dockstore. Outside of Terra, no convenient mechanism exists.

This PR adds such functionality to the `submit` command. First, we automatically detect when a workflow has relative imports (simply looking for the '../' indicator in the import path). Next, we create a temporary directory. We then recurse the dependency structure of the submitted WDL.  We rewrite each WDL to the temporary directory, adjusting the imports to point to the temporary directory as we go. We also ensure that the aliasing of WDLs remains correct by adding it where necessary.

To see this in action, consider the following directory structure. The `HelloWorkflow.wdl` imports files from directories above it, which works in Dockstore/Terra, but fails to run through Cromwell via cromshell.

```
[ 192]  /Users/kiran/repositories/aou-lr/wdl/
├── [ 352]  lib
│   ├── [ 480]  Utility
│   │   ├── [ 85K]  Utils.wdl
├── [  96]  pipelines
│   └── [ 580]  HelloWorkflow.wdl
├── [  96]  structs
│   └── [ 251]  Structs.wdl
└── [  96]  tasks
    └── [ 462]  HelloTask.wdl
```

To fix this, `cromshell submit` flattens out the directory structure within a temporary directory, as below.

```
[ 192]  /var/folders/jp/l0z21gnj4f531jw12fvm0bx80000gq/T/cromshell_alce64p_
├── [ 85K]  Users-kiran-repositories-aou-lr-wdl-lib-Utility-Utils.wdl
├── [ 655]  Users-kiran-repositories-aou-lr-wdl-pipelines-HelloWorkflow.wdl
├── [ 251]  Users-kiran-repositories-aou-lr-wdl-structs-Structs.wdl
└── [ 462]  Users-kiran-repositories-aou-lr-wdl-tasks-HelloTask.wdl
```

The submitted workflow, HelloWorkflow.wdl, is also rewritten:

```
version 1.0

import "Users-kiran-repositories-aou-lr-wdl-tasks-HelloTask.wdl" as Hello
import "Users-kiran-repositories-aou-lr-wdl-lib-Utility-Utils.wdl" as Utils

workflow HelloWorkflow {
    meta {
        description: "Example workflow."
    }

    parameter_meta {
        greeting: "The message to print"
    }

    input {
        String greeting
    }

    # Run a task locally defined in this repo
    call Hello.Print { input: message = greeting }

    # Run a task remotely defined in the long-read-pipelines repo
    call Utils.Sum { input: ints = [1, 2, 3] }

    output {
        String message = Print.text
        Int sum = Sum.sum
    }
}
```

And finally, the `dependencies_zip` parameter is overwritten to point to the temporary directory, enabling the automatic zipping of imports.