### PR TITLE
Bug fix for printing machine readable json for metadata and slim-metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "cromshell-draft-release"
+name = "cromshell"
 # Version number is automatically set via bumpversion. DO NOT MODIFY:
 version = "2.0.0"
 readme = "README.md"

--- a/src/cromshell/metadata/command.py
+++ b/src/cromshell/metadata/command.py
@@ -39,7 +39,7 @@ def main(config, workflow_id: str, dont_expand_subworkflows: bool):
         dont_expand_subworkflows=dont_expand_subworkflows,
     )
 
-    io_utils.pretty_print_json(format_json=workflow_metadata_json, add_color=True)
+    io_utils.pretty_print_json(format_json=workflow_metadata_json)
 
     return 0
 

--- a/src/cromshell/slim_metadata/command.py
+++ b/src/cromshell/slim_metadata/command.py
@@ -69,7 +69,7 @@ def main(
         dont_expand_subworkflows=dont_expand_subworkflows,
     )
 
-    io_utils.pretty_print_json(format_json=workflow_metadata_json, add_color=True)
+    io_utils.pretty_print_json(format_json=workflow_metadata_json)
 
     return 0
 


### PR DESCRIPTION
Problem:
adding the `-mc` option will still print a color-highlighted version of a json. 

Change: 
removed `add color` setting for the pretty print json function for metadata and slim-metadata command